### PR TITLE
feature: could provide random values for sm2 key gen & pk point verif…

### DIFF
--- a/src/sm2/index.js
+++ b/src/sm2/index.js
@@ -241,4 +241,5 @@ module.exports = {
   doSignature,
   doVerifySignature,
   getPoint,
+  verifyECPoint: _.verifyECPoint,
 }

--- a/src/sm2/utils.js
+++ b/src/sm2/utils.js
@@ -34,9 +34,12 @@ function generateEcparam() {
 
 /**
  * 生成密钥对：publicKey = privateKey * G
+ * 
+ * @param {Array} [randomValues=null] 随机数数组
  */
-function generateKeyPairHex() {
-  const d = new BigInteger(n.bitLength(), rng).mod(n.subtract(BigInteger.ONE)).add(BigInteger.ONE) // 随机数
+function generateKeyPairHex(randomValues=null) {
+  const rv = randomValues ? new BigInteger(randomValues) : new BigInteger(n.bitLength(), rng)
+  const d = rv.mod(n.subtract(BigInteger.ONE)).add(BigInteger.ONE) // 随机数
   const privateKey = leftPad(d.toString(16), 64)
 
   const P = G.multiply(d) // P = dG，p 为公钥，d 为私钥
@@ -135,6 +138,23 @@ function hexToArray(hexStr) {
   return words
 }
 
+
+/**
+ * 验证公钥是否为椭圆曲线上的点
+ */
+function verifyECPoint(publicKey) {
+  const pkPoint = curve.decodePointHex(publicKey)
+  if (!pkPoint) {
+    return false
+  }
+  const x = pkPoint.getX()
+  const y = pkPoint.getY()
+
+  // y^2 == x^3 + ax + b
+  return y.square()
+          .equals( x.multiply(x.square()).add(x.multiply(curve.a)).add(curve.b) )
+}
+
 module.exports = {
   getGlobalCurve,
   generateEcparam,
@@ -144,4 +164,5 @@ module.exports = {
   arrayToHex,
   arrayToUtf8,
   hexToArray,
+  verifyECPoint,
 }


### PR DESCRIPTION
对sm2建议的两个features:
1. `jsbn`中的伪随机数生成器为RC4，这在[RFC4252](https://datatracker.ietf.org/doc/html/rfc4253)和[RFC7465](https://datatracker.ietf.org/doc/html/rfc7465)中已被指出不安全。可以让开发人员通过其他的方式生成密码学安全的随机数，并传入`sm2.generateKeyPairHex`来生成相应的公私钥对。
2. 在一些应用（如ECDH）中，公钥需要被验证是否在椭圆曲线上，因此该库应该提供这样的接口。