### PR TITLE
fix(Readme): 修复自述文档的错误代码例

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ let point = sm2.getPoint() // 获取一个椭圆曲线点，可在sm2签名时�
 ### 根据私钥获取公钥
 
 ```js
-const sm2 = require('sm-crypto).sm2
+const sm2 = require('miniprogram-sm-crypto').sm2
 
 let publicKey = sm2.getPublicKeyFromPrivateKey(privateKey)
 ```


### PR DESCRIPTION
将自述文档中的

```js
const sm2 = require('sm-crypto).sm2
```

更改为

```js
const sm2 = require('miniprogram-sm-crypto').sm2
```